### PR TITLE
Remove subcommand 'pool remove'

### DIFF
--- a/src/fj/_cli/_core.py
+++ b/src/fj/_cli/_core.py
@@ -109,13 +109,6 @@ def pool_list() -> typing.List[lib.base.Requirement]:
     return pooled_projects
 
 
-def pool_remove(requirements_strs: typing.Iterable[str]) -> None:
-    """Remove from pool."""
-    with lib.base.build_registry(_meta.PROJECT_NAME) as registry:
-        requirements = lib.parser.parse(registry, requirements_strs)
-        lib.pool.remove(registry, requirements)
-
-
 def solve(requirements_strs: typing.Iterable[str]) -> None:
     """Resolve requirements."""
     with lib.base.build_registry(_meta.PROJECT_NAME) as registry:

--- a/src/fj/_cli/main.py
+++ b/src/fj/_cli/main.py
@@ -140,17 +140,6 @@ def _add_pool_args_subparser(subparsers: SubParsers) -> None:
     #
     pool_list_parser = pool_subparsers.add_parser('list', allow_abbrev=False)
     pool_list_parser.set_defaults(_handler=_pool_list)
-    #
-    pool_remove_parser = pool_subparsers.add_parser(
-        'remove',
-        allow_abbrev=False,
-    )
-    pool_remove_parser.set_defaults(_handler=_pool_remove)
-    pool_remove_parser.add_argument(
-        'requirements',
-        metavar='requirement',
-        nargs='+',
-    )
 
 
 def _add_ve_args_subparser(subparsers: SubParsers) -> None:
@@ -260,11 +249,6 @@ def _pool_list(_args: argparse.Namespace) -> None:
     )
     for available_project in sorted_available_projects:
         output(str(available_project))
-
-
-def _pool_remove(args: argparse.Namespace) -> None:
-    raw_requirement_strs = args.requirements
-    _core.pool_remove(raw_requirement_strs)
 
 
 def _solve(args: argparse.Namespace) -> None:

--- a/src/fj/lib/base.py
+++ b/src/fj/lib/base.py
@@ -88,20 +88,6 @@ class Registry:
         pool_dir_path = self._get_user_data_dir_path().joinpath('pool')
         return pool_dir_path
 
-    def get_requirement_dir_path(
-            self,
-            requirement: Requirement,
-    ) -> typing.Optional[pathlib.Path]:
-        """Get path to the directory containing the requirement."""
-        requirement_dir_path = None
-        version_str = get_pinned_requirement_version_str(requirement)
-        if version_str:
-            pool_dir_path = self.get_pool_dir_path()
-            requirement_dir_path = pool_dir_path.joinpath(
-                '{}-{}'.format(requirement.name, version_str),
-            )
-        return requirement_dir_path
-
     def get_temp_dir_path(self) -> pathlib.Path:
         """Get path to temporary directory."""
         return self._temp_dir_path

--- a/src/fj/lib/pool.py
+++ b/src/fj/lib/pool.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import importlib
 import logging
-import shutil
 import typing
 
 import packaging
@@ -187,17 +186,6 @@ def list_(
     pooled_projects = _get_pooled_projects(registry)
     LOGGER.info("list_ %s", pooled_projects)
     return pooled_projects
-
-
-def remove(
-        registry: base.Registry,
-        requirements: typing.Iterable[base.Requirement],
-) -> None:
-    """Remove requirements from pool."""
-    for requirement in requirements:
-        target_dir_path = registry.get_requirement_dir_path(requirement)
-        if target_dir_path and target_dir_path.is_dir():
-            shutil.rmtree(target_dir_path)
 
 
 # EOF


### PR DESCRIPTION
The implementation was buggy.

In the philosophy of this tool, such a command does not entirely make
sense. Removing things from the pool, is not something that should be
necessary. Long term, such a command will be useful, but not for now.